### PR TITLE
Improve RFMiD dataset robustness

### DIFF
--- a/custom_dataset.py
+++ b/custom_dataset.py
@@ -1,32 +1,77 @@
+"""Custom dataset utilities for medical image fine-tuning."""
+
+from typing import Callable, Optional
+
 from torch.utils.data import Dataset
+from torchvision import transforms
 from PIL import Image
 import pandas as pd
 import os
 import torch
+import warnings
 
 class RFMiDDataset(Dataset):
-    def __init__(self, image_dir, csv_path, transform=None):
-        self.image_dir = image_dir
-        self.labels_df = pd.read_csv(csv_path)
-        self.transform = transform
+    """Dataset for multi-label classification of RFMiD retinal images.
 
-    def __len__(self):
+    Parameters
+    ----------
+    image_dir : str
+        Directory containing the image files.
+    csv_path : str
+        Path to the CSV file with image ids and labels.
+    transform : callable, optional
+        Optional transform to be applied on an image.
+    """
+
+    def __init__(self, image_dir: str, csv_path: str,
+                 transform: Optional[Callable] = None) -> None:
+        self.image_dir = image_dir
+        # Read the labels once during initialisation
+        self.labels_df = pd.read_csv(csv_path)
+        # Columns containing the multi-label targets
+        self.label_columns = self.labels_df.columns[3:]
+        self.transform = transform
+        # Size to be used when an image fails to load
+        self._fallback_size = (256, 256)
+
+    def __len__(self) -> int:
+        """Return the total number of samples."""
         return len(self.labels_df)
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int):
+        """Return the image and label tensor at ``idx``.
+
+        Any failure when loading an image results in a warning and a
+        placeholder black image to keep DataLoader behaviour consistent.
+        """
+        if torch.is_tensor(idx):
+            idx = idx.item()
+
         row = self.labels_df.iloc[idx]
-        img_id = str(row['ID']) + '.png'
+        img_id = f"{row['ID']}.png"
         img_path = os.path.join(self.image_dir, img_id)
-        image = Image.open(img_path).convert("RGB")
 
-        # Etiquetas: columnas desde 'ARMD' en adelante (o desde la 3era columna en adelante si es más estable)
-        label_columns = self.labels_df.columns[3:]
-        labels = torch.tensor(row[label_columns].values.astype('float32'))
+        try:
+            with Image.open(img_path) as img:
+                image = img.convert("RGB")
+        except Exception as exc:  # noqa: BLE001
+            warnings.warn(
+                f"Could not load image '{img_path}': {exc}; using blank image instead.")
+            image = Image.new("RGB", self._fallback_size)
 
-
-
+        # Retrieve labels and coerce to float32. Missing values become 0.
+        labels = (
+            row[self.label_columns]
+            .fillna(0)
+            .astype("float32")
+            .to_numpy()
+        )
 
         if self.transform:
             image = self.transform(image)
+        else:
+            image = transforms.ToTensor()(image)
 
-        return image, labels
+        labels_tensor = torch.from_numpy(labels)
+
+        return image, labels_tensor

--- a/engine_finetune.py
+++ b/engine_finetune.py
@@ -1,6 +1,107 @@
-# engine_finetune.py - Archivo corregido (dummy)
-def train_one_epoch(...):
-    pass
+import math
+from typing import Optional, Tuple
 
-def evaluate(...):
-    pass
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+
+from sklearn.metrics import roc_auc_score
+
+from util.misc import MetricLogger
+
+
+def train_one_epoch(
+    model: nn.Module,
+    criterion: nn.Module,
+    data_loader: DataLoader,
+    optimizer: torch.optim.Optimizer,
+    device: torch.device,
+    epoch: int,
+    loss_scaler,
+    clip_grad: Optional[float] = None,
+    mixup_fn=None,
+    log_writer=None,
+    args=None,
+) -> dict:
+    """Train ``model`` for a single epoch."""
+    model.train()
+    metric_logger = MetricLogger(delimiter="  ")
+    header = f"Epoch: [{epoch}]"
+
+    for samples, targets in metric_logger.log_every(data_loader, 10, header):
+        samples = samples.to(device, non_blocking=True)
+        targets = targets.to(device, non_blocking=True)
+
+        if mixup_fn is not None:
+            samples, targets = mixup_fn(samples, targets)
+
+        with torch.cuda.amp.autocast():
+            outputs = model(samples)
+            loss = criterion(outputs, targets)
+
+        loss_value = loss.item()
+        if not math.isfinite(loss_value):
+            raise ValueError(f"Loss is {loss_value}, stopping training")
+
+        optimizer.zero_grad(set_to_none=True)
+        loss_scaler(
+            loss,
+            optimizer,
+            clip_grad=clip_grad,
+            parameters=model.parameters(),
+        )
+
+        metric_logger.update(loss=loss_value, lr=optimizer.param_groups[0]["lr"])
+        if log_writer is not None:
+            log_writer.add_scalar("loss/train", loss_value, epoch)
+
+    metric_logger.synchronize_between_processes()
+    print("Averaged stats:", metric_logger)
+    return {k: meter.global_avg for k, meter in metric_logger.meters.items()}
+
+
+@torch.no_grad()
+def evaluate(
+    data_loader: DataLoader,
+    model: nn.Module,
+    device: torch.device,
+    args,
+    epoch: int = 0,
+    mode: str = "val",
+    num_class: int = 1,
+    log_writer=None,
+) -> Tuple[dict, float]:
+    """Evaluate ``model`` and return metrics and ROC-AUC."""
+    criterion = nn.BCEWithLogitsLoss()
+    metric_logger = MetricLogger(delimiter="  ")
+    header = f"Test: {mode}" if mode else "Test"
+
+    model.eval()
+    all_targets = []
+    all_preds = []
+
+    for samples, targets in metric_logger.log_every(data_loader, 10, header):
+        samples = samples.to(device, non_blocking=True)
+        targets = targets.to(device, non_blocking=True)
+
+        with torch.cuda.amp.autocast():
+            outputs = model(samples)
+            loss = criterion(outputs, targets)
+
+        metric_logger.update(loss=loss.item())
+        all_targets.append(targets.cpu())
+        all_preds.append(outputs.sigmoid().cpu())
+
+    metric_logger.synchronize_between_processes()
+
+    if log_writer is not None:
+        log_writer.add_scalar(f"loss/{mode}", metric_logger.loss.global_avg, epoch)
+
+    targets_concat = torch.cat(all_targets)
+    preds_concat = torch.cat(all_preds)
+    try:
+        auc = roc_auc_score(targets_concat.numpy(), preds_concat.numpy(), average="macro")
+    except Exception:
+        auc = 0.0
+
+    return {k: meter.global_avg for k, meter in metric_logger.meters.items()}, auc


### PR DESCRIPTION
## Summary
- improve `RFMiDDataset` to never return `None` and add error handling
- add docstrings and comments
- implement simple training and evaluation loops in `engine_finetune.py`

## Testing
- `python -m py_compile custom_dataset.py engine_finetune.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68678228de2c8329a1dd1878ee32d154