### PR TITLE
Fix evaluation metrics and dataset robustness

### DIFF
--- a/custom_dataset.py
+++ b/custom_dataset.py
@@ -4,7 +4,10 @@ from typing import Callable, Optional
 
 from torch.utils.data import Dataset
 from torchvision import transforms
-from PIL import Image
+from PIL import Image, ImageFile
+
+# Allow loading of truncated/corrupted images instead of raising an error
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 import pandas as pd
 import os
 import torch


### PR DESCRIPTION
## Summary
- handle truncated images in `RFMiDDataset`
- compute ROC‑AUC and F1 in evaluation
- log AUC and F1 during training
- fix evaluation-only path to load checkpoints properly

## Testing
- `python -m py_compile engine_finetune.py main_finetune.py custom_dataset.py`

------
https://chatgpt.com/codex/tasks/task_e_68683f0d39208329b485c9382bc8c8c3