### PR TITLE
Fix FastAPI server for RETFound model

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,52 @@
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import JSONResponse
+from torchvision import transforms
+from PIL import Image
+import torch
+import io
+from models_vit import RETFound_mae
+
+# Initialize FastAPI
+app = FastAPI(title="RETFound Disease Detection API")
+
+# Build model
+model = RETFound_mae(
+    img_size=224,
+    num_classes=27,
+    drop_path_rate=0.2,
+    global_pool=True,
+)
+
+checkpoint_path = "models/checkpoint-best.pth"
+try:
+    checkpoint = torch.load(checkpoint_path, map_location="cpu")
+    model.load_state_dict(checkpoint["model"])
+    model.eval()
+    load_error = None
+except Exception as e:  # pylint: disable=broad-except
+    model = None
+    load_error = str(e)
+
+# Image transforms
+transform = transforms.Compose([
+    transforms.Resize((224, 224)),
+    transforms.ToTensor(),
+])
+
+
+@app.post("/predict")
+async def predict(file: UploadFile = File(...)):
+    if model is None:
+        return JSONResponse(status_code=500, content={"error": f"Model not loaded: {load_error}"})
+    try:
+        image_bytes = await file.read()
+        image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+        input_tensor = transform(image).unsqueeze(0)
+
+        with torch.no_grad():
+            outputs = model(input_tensor)
+            probs = torch.sigmoid(outputs).squeeze().tolist()
+
+        return JSONResponse(content={"probabilities": probs})
+    except Exception as e:  # pylint: disable=broad-except
+        return JSONResponse(status_code=500, content={"error": str(e)})


### PR DESCRIPTION
## Summary
- add properly named `main.py` for FastAPI usage
- load RETFound checkpoint on CPU with error handling
- return sigmoid probabilities for fundus image predictions

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686c32a824f483298a260a172af0f8f0