### PR TITLE
Improve inference logging and error handling

### DIFF
--- a/main .py
+++ b/main .py
@@ -4,7 +4,11 @@ from torchvision import transforms
 from PIL import Image
 import torch
 import io
+import logging
 from models_vit import RETFound_mae
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 # Cargar modelo
 model = RETFound_mae(
@@ -32,14 +36,21 @@ transform = transforms.Compose([
 async def predict(file: UploadFile = File(...)):
     try:
         image_bytes = await file.read()
+        logger.info("Received prediction request: %s (%d bytes)", file.filename, len(image_bytes))
         image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
         input_tensor = transform(image).unsqueeze(0)
+        logger.info("Tensor shape after transforms: %s", tuple(input_tensor.shape))
 
         with torch.no_grad():
-            outputs = model(input_tensor)
+            try:
+                outputs = model(input_tensor)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.exception("Model inference failed")
+                return JSONResponse(status_code=500, content={"error": str(e)})
             probs = torch.sigmoid(outputs).squeeze().tolist()
 
         return JSONResponse(content={"probabilities": probs})
 
     except Exception as e:
+        logger.exception("Prediction failed")
         return JSONResponse(status_code=500, content={"error": str(e)})

--- a/main.py
+++ b/main.py
@@ -67,13 +67,20 @@ async def predict(file: UploadFile = File(...)):
         return JSONResponse(status_code=500, content={"error": f"Model not loaded: {load_error}"})
     try:
         image_bytes = await file.read()
+        logger.info("Received prediction request: %s (%d bytes)", file.filename, len(image_bytes))
         image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
         input_tensor = transform(image).unsqueeze(0)
+        logger.info("Tensor shape after transforms: %s", tuple(input_tensor.shape))
 
         with torch.no_grad():
-            outputs = model(input_tensor)
+            try:
+                outputs = model(input_tensor)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.exception("Model inference failed")
+                return JSONResponse(status_code=500, content={"error": str(e)})
             probs = torch.sigmoid(outputs).squeeze().tolist()
 
         return JSONResponse(content={"probabilities": probs})
     except Exception as e:  # pylint: disable=broad-except
+        logger.exception("Prediction failed")
         return JSONResponse(status_code=500, content={"error": str(e)})


### PR DESCRIPTION
## Summary
- log inference request details
- trace inference tensor shapes
- catch `model` inference errors
- report stack traces in API

## Testing
- `pytest -q`
- `python -m py_compile main.py "main .py"`

------
https://chatgpt.com/codex/tasks/task_e_686dc4abfa3c83298cd2defa4f5129e2