### PR TITLE
Add GPT explanations to prediction endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ matplotlib~=3.8.4
 scikit-multilearn~=0.2.0
 huggingface-hub~=0.23.4pandas~=2.2.2
 tensorboard~=2.17.0
+openai~=1.30.1


### PR DESCRIPTION
## Summary
- augment `/predict` with GPT-generated medical explanations
- expose top 5 disease predictions only
- configure OpenAI API via `OPENAI_API_KEY`
- add `openai` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68701cddedcc8329b0dd2fc4fff5a2ee