### PR TITLE
Migrate to OpenAI client

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,13 +6,12 @@ import torch
 import io
 import logging
 import argparse
-import os
-import openai
+from openai import OpenAI
 from models_vit import RETFound_mae
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-openai.api_key = os.getenv("OPENAI_API_KEY")
+client = OpenAI()
 
 # Labels for the RFMiD dataset in order corresponding to model outputs
 disease_labels = [
@@ -111,7 +110,7 @@ async def predict(file: UploadFile = File(...)):
         )
 
         try:
-            completion = openai.ChatCompletion.create(
+            response = client.chat.completions.create(
                 model="gpt-4",
                 temperature=0.7,
                 messages=[
@@ -119,7 +118,7 @@ async def predict(file: UploadFile = File(...)):
                     {"role": "user", "content": prompt},
                 ],
             )
-            summary = completion["choices"][0]["message"]["content"].strip()
+            summary = response.choices[0].message.content.strip()
         except Exception as e:  # pylint: disable=broad-except
             logger.exception("OpenAI API call failed")
             summary = f"Failed to generate explanation: {e}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ matplotlib~=3.8.4
 scikit-multilearn~=0.2.0
 huggingface-hub~=0.23.4pandas~=2.2.2
 tensorboard~=2.17.0
-openai~=1.30.1
+openai>=1.1.1


### PR DESCRIPTION
## Summary
- import `OpenAI` client and initialize it
- call `client.chat.completions.create` when fetching GPT output
- require `openai>=1.1.1`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687064ea88c08329ab21d0a9c7b9d231